### PR TITLE
fix b'\xef\xb8\x8f' bug

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,24 @@
+import pygame
+import pygame_emojis
+
+# Initialize Pygame and create a window
+pygame.init()
+screen = pygame.display.set_mode((640, 480))
+
+# Load and render emojis
+emojis = pygame_emojis.emojis(screen)
+emojis.render_text_and_emojis("Hello /e😀/e /e👍/e", (255, 255, 255), (0, 0), 60)
+emojis.render_text_and_emojis("yes /e🐔/e/e🍾/e/e⛷/e️", (255, 255, 255), (0, 60), 60)
+
+# Update the display
+pygame.display.flip()
+
+# Main loop
+running = True
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+
+# Quit Pygam
+pygame.quit()

--- a/pygame_emojis.py
+++ b/pygame_emojis.py
@@ -3,6 +3,7 @@ import requests
 from io import BytesIO
 from time import *
 from emoji import *
+import re
 
 memory = {}
 
@@ -48,9 +49,13 @@ class emojis:
         parts = text.split("/e")
         font = pygame.font.Font(None, font_size)
         current_x = x
+        byte_pattern = re.compile(b'\xef\xb8\x8f')
 
         for i, part in enumerate(parts):
             if part:
+                if byte_pattern.search(part.encode()):
+                    part = part.encode().replace(b'\xef\xb8\x8f', b"").decode()
+
                 if i % 2 == 0:
                     text_surface = font.render(part, True, (v, b, w))
                     text_rect = text_surface.get_rect()
@@ -63,5 +68,6 @@ class emojis:
                     current_x += scaled_emoji.get_width()
 
         if parts[-1]:
-            text_surface = font.render(parts[-1], True, (v, b, w))
+            part = parts[-1].encode().replace(b'\xef\xb8\x8f', b"").decode()
+            text_surface = font.render(part, True, (v, b, w))
             screen.blit(text_surface, (current_x, y))


### PR DESCRIPTION
An error occurs when running example.py. 
When b'\xef\xb8\x8f' appears in the 'part' variable within the for-loop of the `render_text_and_emojis ` function, it triggers a pygame.error: "Text has zero width". To resolve this, I used the `re` module to replace all occurrences of b'\xef\xb8\x8f' in the text for rendering.